### PR TITLE
[PAR-778] Bump integration-core to ~5.2.0 for active_theme support in store info payload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^8.4",
         "ext-json": "*",
         "laravel/framework": "^12.36.0",
-        "sequra/integration-core": "^5.1.3"
+        "sequra/integration-core": "~5.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50b73311488d0e0b96e8f1aebc0e2237",
+    "content-hash": "90ecb90398c09916151b12eb62c6b386",
     "packages": [
         {
             "name": "brick/math",
@@ -3095,16 +3095,16 @@
         },
         {
             "name": "sequra/integration-core",
-            "version": "v5.1.3",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sequra/integration-core.git",
-                "reference": "7750111e034bb8184ba5a7b8df91b9dd75aa3323"
+                "reference": "b764f84cc87f0cd7c0d7009942100e7a1f892199"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sequra/integration-core/zipball/7750111e034bb8184ba5a7b8df91b9dd75aa3323",
-                "reference": "7750111e034bb8184ba5a7b8df91b9dd75aa3323",
+                "url": "https://api.github.com/repos/sequra/integration-core/zipball/b764f84cc87f0cd7c0d7009942100e7a1f892199",
+                "reference": "b764f84cc87f0cd7c0d7009942100e7a1f892199",
                 "shasum": ""
             },
             "require": {
@@ -3133,9 +3133,9 @@
             "description": "Core SeQura integration library",
             "support": {
                 "issues": "https://github.com/sequra/integration-core/issues",
-                "source": "https://github.com/sequra/integration-core/tree/v5.1.3"
+                "source": "https://github.com/sequra/integration-core/tree/v5.2.0"
             },
-            "time": "2026-05-22T07:34:08+00:00"
+            "time": "2026-05-22T10:39:34+00:00"
         },
         {
             "name": "symfony/clock",


### PR DESCRIPTION
### What is the goal?

Bumps `sequra/integration-core` from `^5.1.3` to `~5.2.0`. v5.2.0 introduces an optional `active_theme` property on the store info payload (`StoreInfo`) so downstream integrators can surface the merchant's currently active storefront theme alongside the existing platform/plugin/php/db/os fields.

The bump is fully backwards-compatible: `activeTheme` is an optional trailing constructor arg defaulting to `null`, and `StoreInfoServiceInterface` is unchanged — no integrator is forced to change anything to upgrade.

### References
* **Issue:** PAR-778

### How is it being implemented?

- Composer constraint bumped from `^5.1.3` to `~5.2.0` (patch-only range within 5.2.x, more conservative than the prior `^` style on the 5.1.3 bump).
- `composer.lock` refreshed via `composer update sequra/integration-core --with-all-dependencies`. Only the core itself moved (v5.1.3 → v5.2.0); no transitive churn.
- Audited `src/BootstrapComponent.php::initRepositories()` against `vendor/sequra/integration-core/src/BusinessLogic/DataAccess/`. 5.2.0 introduces no new persisted entity; all 12 DataAccess entities remain registered. No bootstrap change needed (unlike the prior 5.1.3 bump which had to register `AdvancedSettings`).
- Verified the 5.2.0 `StoreInfo` shape in `vendor/sequra/integration-core/src/BusinessLogic/Domain/Stores/Models/StoreInfo.php`: new optional 10th constructor arg `?string $activeTheme = null`, new getter `getActiveTheme(): ?string`, `toArray()`/`fromArray()` round-trip the `active_theme` key. `StoreInfoServiceInterface::getStoreInfo()` signature is unchanged.

### Caveats

- Downstream integrators implementing `StoreInfoServiceInterface` do **not** need to change anything to upgrade — `activeTheme` is optional and defaults to `null`.
- To populate the new field, integrators pass the theme name as the 10th constructor arg of `StoreInfo`; existing call sites continue to compile and run unchanged.

### Does it affect (changes or update) any sensitive data?

No — this change only touches `composer.json` / `composer.lock`. No schema migrations, no payload-handling code in this middleware.

### How is it tested?

- `composer validate` passes after the bump.
- `vendor/bin/phpunit` was not re-run locally for this bump (the local test env is not bootstrapped). The middleware `src/` is untouched by this change — only the composer manifest and lock — so existing repository/logger tests are not affected. Please re-run the suite as part of standard review if desired.

### How is it going to be deployed?

Standard deployment.

## Commits

- baeceb9 PAR-778: step 2 - refresh composer.lock to integration-core v5.2.0
- 14ecd61 PAR-778: step 1 - bump integration-core constraint to ~5.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)