### PR TITLE
[PAR-778] Bump integration-core to ~5.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^8.4",
         "ext-json": "*",
         "laravel/framework": "^12.36.0",
-        "sequra/integration-core": "~5.2.0"
+        "sequra/integration-core": "~5.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "90ecb90398c09916151b12eb62c6b386",
+    "content-hash": "40b7fad2df1a53591da24ae44187e910",
     "packages": [
         {
             "name": "brick/math",
@@ -3095,16 +3095,16 @@
         },
         {
             "name": "sequra/integration-core",
-            "version": "v5.2.0",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sequra/integration-core.git",
-                "reference": "b764f84cc87f0cd7c0d7009942100e7a1f892199"
+                "reference": "0f7b744b82743a6eb86863838200227f3202ec4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sequra/integration-core/zipball/b764f84cc87f0cd7c0d7009942100e7a1f892199",
-                "reference": "b764f84cc87f0cd7c0d7009942100e7a1f892199",
+                "url": "https://api.github.com/repos/sequra/integration-core/zipball/0f7b744b82743a6eb86863838200227f3202ec4b",
+                "reference": "0f7b744b82743a6eb86863838200227f3202ec4b",
                 "shasum": ""
             },
             "require": {
@@ -3133,9 +3133,9 @@
             "description": "Core SeQura integration library",
             "support": {
                 "issues": "https://github.com/sequra/integration-core/issues",
-                "source": "https://github.com/sequra/integration-core/tree/v5.2.0"
+                "source": "https://github.com/sequra/integration-core/tree/v5.3.0"
             },
-            "time": "2026-05-22T10:39:34+00:00"
+            "time": "2026-05-22T15:09:26+00:00"
         },
         {
             "name": "symfony/clock",


### PR DESCRIPTION
### What is the goal?

Bumps `sequra/integration-core` from `~5.2.0` to `~5.3.0`. v5.3.0 introduces an optional `StoreUrlProviderInterface` (sequra/integration-core#62) that lets integrations expose a cheap `getStoreUrl()` lookup for the webhook HMAC payload, avoiding the cost of building a full `StoreInfo` on every register, delete and inbound webhook validation.

The bump is fully backwards-compatible: `StoreUrlProviderInterface` is a new optional companion to `StoreInfoServiceInterface`, and `StoreInfoServiceInterface` itself is unchanged — no integrator is forced to change anything to upgrade.

### References
* **Issue:** PAR-778
* **Related pull-requests:** sequra/integration-core#62

### How is it being implemented?

- Composer constraint bumped from `~5.2.0` to `~5.3.0`.
- `composer.lock` refreshed via `composer update sequra/integration-core --with-dependencies`. Only the core itself moved (v5.2.0 → v5.3.0); no transitive churn.
- No middleware `src/` change. The new interface is a downstream integrator-level opt-in; the middleware itself does not provide a `StoreInfoServiceInterface` implementation, so nothing here needs to opt in.

### Caveats

- Integrators implementing `StoreInfoServiceInterface` do **not** need to change anything to upgrade — the new interface is pure opt-in.
- Integrators whose `getStoreInfo()` is expensive (live API calls to populate fields the HMAC does not use) can adopt by adding `implements StoreUrlProviderInterface` alongside their existing `StoreInfoServiceInterface` and returning a cheap storeUrl string. Signatures are byte-identical across both paths, so adoption never invalidates a previously-issued webhook URL.

### Does it affect (changes or update) any sensitive data?

No — this change only touches `composer.json` / `composer.lock`. The HMAC payload, signature secret and inbound webhook validation behaviour upstream are unchanged.

### How is it tested?

- `composer validate --strict` passes after the bump.
- `vendor/bin/phpunit` was not re-run locally (the local test env is not bootstrapped — pre-existing limitation unchanged by this PR). The middleware `src/` is untouched, so existing tests are not affected.

### How is it going to be deployed?

Standard deployment. Tag the next minor (v3.2.0) once merged; downstream integrators pick it up via their existing `^3.0` constraints on `sequra/middleware`.
